### PR TITLE
Fix: Reload config on each run to support Docker config changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -4499,6 +4499,10 @@ class NewsAnalyzer:
         try:
             self._initialize_and_check_config()
 
+            # 如果爬虫功能被禁用，直接退出
+            if not CONFIG["ENABLE_CRAWLER"]:
+                return
+
             mode_strategy = self._get_mode_strategy()
 
             results, id_to_name, failed_ids = self._crawl_data()
@@ -4511,7 +4515,11 @@ class NewsAnalyzer:
 
 
 def main():
+    global CONFIG
     try:
+        # 每次运行时重新加载配置，确保Docker环境下配置文件修改能生效
+        CONFIG = load_config()
+        print(f"TrendRadar v{VERSION} 配置重新加载完成")
         analyzer = NewsAnalyzer()
         analyzer.run()
     except FileNotFoundError as e:


### PR DESCRIPTION
Fixes issue #163 where config.yaml modifications were not picked up in Docker deployments

## Problem
In Docker deployments (especially on Feiniu NAS), config.yaml changes were not being read because the CONFIG was loaded once at module import time and cached throughout the process lifetime.

## Solution
- Move CONFIG loading from module level to main() function so config is reloaded on each execution
- Add early return in run() method when crawler is disabled to prevent unnecessary processing
- This ensures Docker cron jobs pick up config changes on each run

## Testing
- Verified config changes are now picked up on each run
- Confirmed enable_crawler=false properly disables crawling without running data fetch operations
- All other config options (report mode, push window, webhooks, etc.) are now reloadable

Resolves: https://github.com/sansan0/TrendRadar/issues/163