### PR TITLE
feat: 增加平台级关键词过滤

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -1383,6 +1383,27 @@ If you don't know how to look, you can directly copy the partially organized [Pl
 
 </details>
 
+#### 1.1 Platform-level keyword filters
+
+<details id="platform-level-black-words">
+<summary>👉 Click to expand: <strong>Platform-level keyword</strong></summary>
+<br>
+
+Different content sources have different noise patterns.
+
+Platform-level filters allow much more precise content control and reduce false positives.
+
+Each platform in `config/config.yaml` can define `blackWords` that will cause an item to be skipped if the title contains them.
+
+```yaml
+platforms:
+  - id: "zhihu"
+    name: "Zhihu"
+    blackWords: ["How should we view", "How would you evaluate"]
+```
+
+</details>
+
 ### 2. Keyword Configuration
 
 Configure monitoring keywords in `frequency_words.txt` with four syntax types and grouping features.

--- a/README.md
+++ b/README.md
@@ -1433,6 +1433,25 @@ platforms:
 
 </details>
 
+#### 1.1 平台关键词过滤
+
+<details id="平台关键词过滤">
+<summary>👉 点击展开：<strong>平台关键词过滤示例</strong></summary>
+<br>
+
+不同平台的用户习惯不同，垃圾内容也不同，通过平台级过滤词，可以减少垃圾信息，提升抓取内容质量。
+
+如果要启用平台级关键词过滤，请在 `config/config.yaml` 文件中修改 `platforms` 配置，添加 `blackWords`
+
+```yaml
+platforms:
+  - id: "zhihu"
+    name: "知乎"
+    blackWords: ["如何看待", "如何评价"]
+```
+
+</details>
+
 ### 2. 关键词配置
 
 在 `frequency_words.txt` 文件中配置监控的关键词，支持四种语法和词组功能。

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,3 +119,4 @@ platforms:
     name: "抖音"
   - id: "zhihu"
     name: "知乎"
+    blackWords: ["如何看待", "如何评价"]

--- a/main.py
+++ b/main.py
@@ -554,6 +554,12 @@ class DataFetcher:
             id_to_name[id_value] = name
             response, _, _ = self.fetch_data(id_info)
 
+            # 获取当前平台配置
+            platform_config = next(
+                (p for p in CONFIG["PLATFORMS"] if p["id"] == id_value),
+                None
+            )
+
             if response:
                 try:
                     data = json.loads(response)
@@ -566,6 +572,18 @@ class DataFetcher:
                         title = str(title).strip()
                         url = item.get("url", "")
                         mobile_url = item.get("mobileUrl", "")
+
+                        # 过滤标题
+                        if platform_config and "blackWords" in platform_config:
+                            lower_title = title.lower()
+                            skip_title = False
+                            for bw in platform_config["blackWords"]:
+                                if bw.lower() in lower_title:
+                                    skip_title = True
+                                    break
+                            if skip_title:
+                                print(f"[过滤] {id_value} 过滤标题: {title}")
+                                continue
 
                         if title in results[id_value]:
                             results[id_value][title]["ranks"].append(index)


### PR DESCRIPTION
# 功能说明

增加了平台级黑名单词过滤能力，允许在 config.yaml 的 platforms 中为每个平台定义 blackWords，用于过滤标题中包含这些词的条目。

# 改动点

在 config.yaml 中可添加 blackWords 字段，与 frequency_words.txt 完全兼容，示例：

```yaml
platforms:
  - id: "zhihu"
    name: "知乎"
    blackWords: ["如何看待", "如何评价"]
```

# 为什么需要这个改动

不同平台的用户用词习惯不同，可以通过平台级过滤词，忽略不希望抓取的内容。