### PR TITLE
Security: Enforce non-root user in Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,11 @@ RUN sed -i 's/\r$//' /entrypoint.sh.tmp && \
     mv /entrypoint.sh.tmp /entrypoint.sh && \
     chmod +x /entrypoint.sh && \
     chmod +x manage.py && \
-    mkdir -p /app/config /app/output
+    mkdir -p /app/config /app/output && \
+    addgroup -S trendradar && adduser -S trendradar -G trendradar && \
+    chown -R trendradar:trendradar /app
+
+USER trendradar
 
 ENV PYTHONUNBUFFERED=1 \
     CONFIG_PATH=/app/config/config.yaml \


### PR DESCRIPTION
Implement least privilege principle by migrating container execution from root to a dedicated non-privileged user.

Running processes as root within a container poses a significant security risk, potentially allowing for container escape and host compromise if the application is exploited. This change creates a `trendradar` user/group and ensures all runtime operations are restricted to that user's permissions.