### PR TITLE
Support Zeabur platform deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY docker/manage.py .
 COPY trendradar/ ./trendradar/
 
 # 复制配置文件
-COPY config/ /app/config/
+COPY config/ ./config/
 
 # 复制 entrypoint.sh 并强制转换为 LF 格式
 COPY docker/entrypoint.sh /entrypoint.sh.tmp
@@ -65,7 +65,7 @@ RUN sed -i 's/\r$//' /entrypoint.sh.tmp && \
     mv /entrypoint.sh.tmp /entrypoint.sh && \
     chmod +x /entrypoint.sh && \
     chmod +x manage.py && \
-    mkdir -p /app/config /app/output
+    mkdir -p ./config ./output
 
 ENV PYTHONUNBUFFERED=1 \
     CONFIG_PATH=/app/config/config.yaml \


### PR DESCRIPTION
# Zeabur 部署 TrendRadar 完整指南

> 🚀 使用 Zeabur 云平台快速部署 TrendRadar，无需购买服务器，支持自动部署和定时任务


## 关于 Zeabur

**Zeabur** 是一个现代化的应用部署平台，支持从 Git 仓库自动构建和部署应用程序。对于 TrendRadar 项目，Zeabur 提供：

- ✅ **零运维部署**：自动构建 Docker 镜像并运行
- ✅ **Git 集成**：代码更新自动重新部署
- ✅ **永久运行**：支持 Cron 定时任务持续运行
- ✅ **免费额度**：提供免费套餐供个人使用

---

## 部署优势

| 对比项         | Zeabur 部署         | Docker 本地部署     | GitHub Actions              |
| -------------- | ------------------- | ------------------- | --------------------------- |
| **服务器要求** | ❌ 无需服务器       | ✅ 需要 VPS/NAS     | ❌ 使用 GitHub              |
| **维护成本**   | 🟢 低（平台托管）   | 🟡 中（需自行维护） | 🟢 低（GitHub 维护）        |
| **定时精准度** | 🟢 精准             | 🟢 精准             | 🔴 不精准（延迟 5-15 分钟） |
| **数据持久化** | 🟢 支持             | 🟢 支持             | 🟡 需配置云存储             |
| **部署难度**   | 🟢 简单（界面操作） | 🟡 中等（命令行）   | 🟡 中等（YAML 配置）        |
| **费用**       | 💰 免费额度 + 付费  | 💰 服务器费用       | 💰 免费                     |

---

## 前置准备

### 1. 账号准备

- [x] **GitHub 账号**：用于托管代码
- [x] **Zeabur 账号**：[注册地址](https://zeabur.com/)（可使用 GitHub 登录）

### 2. 代码准备

**方式一：Fork 原仓库（推荐）**

1. 访问 [TrendRadar 仓库](https://github.com/sansan0/TrendRadar)
2. 点击右上角 `Fork` 按钮
3. Fork 到你的 GitHub 账号

## 部署

1. 访问 [Zeabur 控制台](https://zeabur.com/dashboard)
2. 点击 **「New Project」** 创建新项目
3. 输入项目名称（如 `trendradar`）
4. 点击 **「Add Service」**
5. 选择 **「GitHub」** 方式部署
6. 授权 GitHub 并选择你的 TrendRadar 仓库
7. Zeabur 会自动检测到项目根目录的 `Dockerfile` 并开始构建
8. 构建完成后，Zeabur 会自动启动服务
9. 配置映射文件`Settings` -> `Configs` -> `Open Config Editor` -> `Add config file` -> 输入`/app/config/config.yaml`并复制你的`config.yaml`文件内容(按需要调整)
10. 返回服务首页 进行 重新部署即可.

