### PR TITLE
feat: add custom API links to prevent domain name links from being re…

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -256,6 +256,7 @@ advanced:
   # 爬虫设置
   crawler:
     enabled: true                     # 是否启用爬取新闻功能
+    api_url: "https://newsnow.busiyi.world/api/s"  # NewsNow API 地址（可自定义）
     request_interval: 1000            # 请求间隔（毫秒）
     use_proxy: false                  # 是否启用代理
     default_proxy: "http://127.0.0.1:10801"

--- a/mcp_server/tools/system.py
+++ b/mcp_server/tools/system.py
@@ -142,11 +142,12 @@ class SystemManagementTools:
             # 初始化数据获取器
             advanced = config_data.get("advanced", {})
             crawler_config = advanced.get("crawler", {})
+            api_url = crawler_config.get("api_url", "https://newsnow.busiyi.world/api/s")
             proxy_url = None
             if crawler_config.get("use_proxy"):
                 proxy_url = crawler_config.get("default_proxy")
-            
-            fetcher = DataFetcher(proxy_url=proxy_url)
+
+            fetcher = DataFetcher(api_url=api_url, proxy_url=proxy_url)
             request_interval = crawler_config.get("request_interval", 100)
 
             # 执行爬取

--- a/trendradar/__main__.py
+++ b/trendradar/__main__.py
@@ -120,7 +120,10 @@ class NewsAnalyzer:
         self.update_info = None
         self.proxy_url = None
         self._setup_proxy()
-        self.data_fetcher = DataFetcher(self.proxy_url)
+        self.data_fetcher = DataFetcher(
+            api_url=self.ctx.config["API_URL"],
+            proxy_url=self.proxy_url
+        )
 
         # 初始化存储管理器（使用 AppContext）
         self._init_storage_manager()

--- a/trendradar/core/loader.py
+++ b/trendradar/core/loader.py
@@ -55,6 +55,7 @@ def _load_crawler_config(config_data: Dict) -> Dict:
     crawler_config = advanced.get("crawler", {})
     enable_crawler_env = _get_env_bool("ENABLE_CRAWLER")
     return {
+        "API_URL": crawler_config.get("api_url", "https://newsnow.busiyi.world/api/s"),
         "REQUEST_INTERVAL": crawler_config.get("request_interval", 100),
         "USE_PROXY": crawler_config.get("use_proxy", False),
         "DEFAULT_PROXY": crawler_config.get("default_proxy", ""),


### PR DESCRIPTION
在使用中发现：

trendradar      | 请求 toutiao 失败: HTTPSConnectionPool(host='newsnow.busiyi.world', port=443): Max retries exceeded with url: /api/s?id=toutiao&latest (Caused by NewConnectionError("HTTPSConnection(host='newsnow.busiyi.world', port=443): Failed to establish a new connection: [Errno 101] Network is unreachable")). 5.74秒后重试...

发现可能由于ip频繁访问被Cloudflare判定为异常流量阻断了连接，观察项目发现不能在配置文件中自定义api地址

增加自定义api_url 在配置文件中所以进行了本次修改