### PR TITLE
Support cloudflare pages

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -161,11 +161,13 @@ jobs:
           S3_REGION: ${{ secrets.S3_REGION }}
           GITHUB_ACTIONS: true
         run: python -m trendradar
-      - name: Deploy
+      - name: Deploy cloudflare pages
+        if: ${{ success() && vars.CLOUDFLARE_PAGE_PROJECT != '' }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # 可以使用pages project list命令查看已有项目名
           # command: |
           #   pages project list
           #   pages deploy output --project-name=${{ vars.CLOUDFLARE_PAGE_PROJECT }}


### PR DESCRIPTION
Inspired by: [Issue 628](https://github.com/sansan0/TrendRadar/issues/628)

添加对cloudflare pages的支持，需要配置下面的参数：
settings -> secrets and variables -> action -> variable:
|名字|说明|
|-----|-----|
|CLOUDFLARE_PAGE_PROJECT| Cloudflare Page project的名字，注意创建的是page，不是worker，否则提示找不到project。之所以把这个放到变量里，不放到secret里，是方便调试，而且project名字也不是敏感信息|


settings -> secrets and variables -> action -> secrets:
|名字|说明|
|-----|-----|
|CLOUDFLARE_ACCOUNT_ID|Account ID|
|CLOUDFLARE_API_TOKEN|选择"编辑 Cloudflare Workers"模板创建API Token|