### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           clean: true
@@ -113,7 +113,7 @@ jobs:
 
       - name: Set up Python
         if: success()
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -58,7 +58,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         env:
           BUILDKIT_PROGRESS: plain
         with:
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -120,7 +120,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         env:
           BUILDKIT_PROGRESS: plain
         with:


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/docker.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/crawler.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/crawler.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docker.yml`
