### PR TITLE
使用交互式卡片修复飞书群消息显示为原始文本的问题

### DIFF
--- a/trendradar/notification/senders.py
+++ b/trendradar/notification/senders.py
@@ -166,12 +166,27 @@ def send_to_feishu(
             f"发送{log_prefix}第 {i}/{len(batches)} 批次，大小：{content_size} 字节 [{report_type}]"
         )
 
-        # 飞书 webhook 只显示 content.text，所有信息都整合到 text 中
+        # 使用飞书交互式卡片（interactive）消息类型
         payload = {
-            "msg_type": "text",
-            "content": {
-                "text": batch_content,
-            },
+            "msg_type": "interactive",
+            "card": {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {
+                        "tag": "plain_text",
+                        "content": "热点追踪"
+                    }
+                },
+                "elements": [
+                    {
+                        "tag": "div",
+                        "text": {
+                            "tag": "lark_md",
+                            "content": batch_content
+                        }
+                    }
+                ]
+            }
         }
 
         try:


### PR DESCRIPTION
原来在飞书中显示为：
<img width="1314" height="485" alt="image" src="https://github.com/user-attachments/assets/7fae165f-56bd-4195-a056-cacc1929d412" />
修复后为：
<img width="800" height="555" alt="image" src="https://github.com/user-attachments/assets/0f6894af-721a-4883-86fb-a997a2a3ff8d" />
