### PR TITLE
feat(dingtalk): add signature support with auto-adapt for security modes

### DIFF
--- a/trendradar/core/loader.py
+++ b/trendradar/core/loader.py
@@ -372,6 +372,7 @@ def _load_webhook_config(config_data: Dict) -> Dict:
         "FEISHU_WEBHOOK_URL": _get_env_str("FEISHU_WEBHOOK_URL") or feishu.get("webhook_url", ""),
         # 钉钉
         "DINGTALK_WEBHOOK_URL": _get_env_str("DINGTALK_WEBHOOK_URL") or dingtalk.get("webhook_url", ""),
+        "DINGTALK_SECRET": _get_env_str("DINGTALK_SECRET") or dingtalk.get("secret", ""),
         # 企业微信
         "WEWORK_WEBHOOK_URL": _get_env_str("WEWORK_WEBHOOK_URL") or wework.get("webhook_url", ""),
         "WEWORK_MSG_TYPE": _get_env_str("WEWORK_MSG_TYPE") or wework.get("msg_type", "markdown"),

--- a/trendradar/notification/dispatcher.py
+++ b/trendradar/notification/dispatcher.py
@@ -357,22 +357,32 @@ class NotificationDispatcher:
         display_regions: Optional[Dict] = None,
         standalone_data: Optional[Dict] = None,
     ) -> bool:
-        """发送到钉钉（多账号，支持热榜+RSS合并+AI分析+独立展示区）"""
+        """发送到钉钉（多账号，支持热榜+RSS合并+AI分析+独立展示区，支持加签）"""
         display_regions = display_regions or {}
         if not display_regions.get("HOTLIST", True):
             report_data = {"stats": [], "failed_ids": [], "new_titles": [], "id_to_name": {}}
 
-        return self._send_to_multi_accounts(
-            channel_name="钉钉",
-            config_value=self.config["DINGTALK_WEBHOOK_URL"],
-            send_func=lambda url, account_label: send_to_dingtalk(
-                webhook_url=url,
+        webhooks = parse_multi_account_config(self.config["DINGTALK_WEBHOOK_URL"])
+        secrets = parse_multi_account_config(self.config.get("DINGTALK_SECRET", ""))
+        webhooks = limit_accounts(webhooks, self.max_accounts, "钉钉")
+
+        results = []
+        for i, webhook_url in enumerate(webhooks):
+            if not webhook_url:
+                continue
+
+            account_label = f"账号{i+1}" if len(webhooks) > 1 else ""
+            secret = secrets[i] if i < len(secrets) else ""
+
+            result = send_to_dingtalk(
+                webhook_url=webhook_url,
                 report_data=report_data,
                 report_type=report_type,
                 update_info=update_info,
                 proxy_url=proxy_url,
                 mode=mode,
                 account_label=account_label,
+                secret=secret,
                 batch_size=self.config.get("DINGTALK_BATCH_SIZE", 20000),
                 batch_interval=self.config.get("BATCH_SEND_INTERVAL", 1.0),
                 split_content_func=self.split_content_func,
@@ -381,8 +391,10 @@ class NotificationDispatcher:
                 ai_analysis=ai_analysis if display_regions.get("AI_ANALYSIS", True) else None,
                 display_regions=display_regions,
                 standalone_data=standalone_data if display_regions.get("STANDALONE", False) else None,
-            ),
-        )
+            )
+            results.append(result)
+
+        return any(results) if results else False
 
     def _send_wework(
         self,

--- a/trendradar/notification/senders.py
+++ b/trendradar/notification/senders.py
@@ -330,31 +330,46 @@ def send_to_dingtalk(
         }
 
         try:
-            # 如果配置了加签密钥，生成签名URL
-            request_url = webhook_url
-            if secret:
-                timestamp, sign = _generate_dingtalk_sign(secret)
-                request_url = f"{webhook_url}&timestamp={timestamp}&sign={sign}"
-
             response = requests.post(
-                request_url, headers=headers, json=payload, proxies=proxies, timeout=30
+                webhook_url, headers=headers, json=payload, proxies=proxies, timeout=30
             )
             if response.status_code == 200:
                 result = response.json()
-                if result.get("errcode") == 0:
+                errcode = result.get("errcode")
+                errmsg = result.get("errmsg", "")
+                
+                if errcode == 0:
                     print(f"{log_prefix}第 {i}/{len(batches)} 批次发送成功 [{report_type}]")
-                    # 批次间间隔
                     if i < len(batches):
                         time.sleep(batch_interval)
+                elif "签名" in errmsg or "sign" in errmsg.lower():
+                    if secret:
+                        print(f"{log_prefix}第 {i}/{len(batches)} 批次签名验证失败，重新计算签名发送 [{report_type}]")
+                        timestamp, sign = _generate_dingtalk_sign(secret)
+                        request_url = f"{webhook_url}&timestamp={timestamp}&sign={sign}"
+                        retry_response = requests.post(
+                            request_url, headers=headers, json=payload, proxies=proxies, timeout=30
+                        )
+                        if retry_response.status_code == 200:
+                            retry_result = retry_response.json()
+                            if retry_result.get("errcode") == 0:
+                                print(f"{log_prefix}第 {i}/{len(batches)} 批次发送成功(加签) [{report_type}]")
+                                if i < len(batches):
+                                    time.sleep(batch_interval)
+                            else:
+                                print(f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，错误：{retry_result.get('errmsg')}")
+                                return False
+                        else:
+                            print(f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，状态码：{retry_response.status_code}")
+                            return False
+                    else:
+                        print(f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，错误：{errmsg}（未配置DINGTALK_SECRET）")
+                        return False
                 else:
-                    print(
-                        f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，错误：{result.get('errmsg')}"
-                    )
+                    print(f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，错误：{errmsg}")
                     return False
             else:
-                print(
-                    f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，状态码：{response.status_code}"
-                )
+                print(f"{log_prefix}第 {i}/{len(batches)} 批次发送失败 [{report_type}]，状态码：{response.status_code}")
                 return False
         except Exception as e:
             print(f"{log_prefix}第 {i}/{len(batches)} 批次发送出错 [{report_type}]：{e}")

--- a/trendradar/notification/senders.py
+++ b/trendradar/notification/senders.py
@@ -18,6 +18,10 @@
 import smtplib
 import time
 import json
+import hmac
+import hashlib
+import base64
+import urllib.parse
 from datetime import datetime
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
@@ -44,6 +48,25 @@ def _render_ai_analysis(ai_analysis: Any, channel: str) -> str:
         return renderer(ai_analysis)
     except ImportError:
         return ""
+
+
+def _generate_dingtalk_sign(secret: str) -> tuple:
+    """
+    生成钉钉加签参数
+
+    Args:
+        secret: 钉钉机器人的加签密钥（SEC开头）
+
+    Returns:
+        tuple: (timestamp, sign) 时间戳和签名
+    """
+    timestamp = str(int(round(time.time() * 1000)))
+    string_to_sign = f"{timestamp}\n{secret}"
+    string_to_sign_enc = string_to_sign.encode("utf-8")
+    secret_enc = secret.encode("utf-8")
+    hmac_code = hmac.new(secret_enc, string_to_sign_enc, digestmod=hashlib.sha256).digest()
+    sign = urllib.parse.quote_plus(base64.b64encode(hmac_code))
+    return timestamp, sign
 
 
 # === SMTP 邮件配置 ===
@@ -214,6 +237,7 @@ def send_to_dingtalk(
     proxy_url: Optional[str] = None,
     mode: str = "daily",
     account_label: str = "",
+    secret: str = "",
     *,
     batch_size: int = 20000,
     batch_interval: float = 1.0,
@@ -225,7 +249,7 @@ def send_to_dingtalk(
     standalone_data: Optional[Dict] = None,
 ) -> bool:
     """
-    发送到钉钉（支持分批发送，支持热榜+RSS合并+独立展示区）
+    发送到钉钉（支持分批发送，支持热榜+RSS合并+独立展示区，支持加签）
 
     Args:
         webhook_url: 钉钉 Webhook URL
@@ -235,6 +259,7 @@ def send_to_dingtalk(
         proxy_url: 代理 URL（可选）
         mode: 报告模式 (daily/current)
         account_label: 账号标签（多账号时显示）
+        secret: 钉钉机器人加签密钥（可选，SEC开头）
         batch_size: 批次大小（字节）
         batch_interval: 批次发送间隔（秒）
         split_content_func: 内容分批函数
@@ -305,8 +330,14 @@ def send_to_dingtalk(
         }
 
         try:
+            # 如果配置了加签密钥，生成签名URL
+            request_url = webhook_url
+            if secret:
+                timestamp, sign = _generate_dingtalk_sign(secret)
+                request_url = f"{webhook_url}&timestamp={timestamp}&sign={sign}"
+
             response = requests.post(
-                webhook_url, headers=headers, json=payload, proxies=proxies, timeout=30
+                request_url, headers=headers, json=payload, proxies=proxies, timeout=30
             )
             if response.status_code == 200:
                 result = response.json()


### PR DESCRIPTION
## 功能

- 支持钉钉加签验证（DINGTALK_SECRET 环境变量）
- 自动适配安全模式：关键词/IP白名单/加签
- 支持多账号（分号分隔）
- 向后兼容：不配置 SECRET 时使用关键词/IP白名单模式

## 用法

```yaml
# docker-compose.yml 或 .env
DINGTALK_WEBHOOK_URL: https://oapi.dingtalk.com/robot/send?access_token=xxx
DINGTALK_SECRET: SECxxx  # 可选，加签模式需要
```

多账号支持：
```bash
DINGTALK_WEBHOOK_URL=https://oapi.dingtalk.com/...;https://oapi.dingtalk.com/...
DINGTALK_SECRET=SECxxx;SECyyy
```

## 工作原理

1. 首先尝试不加签发送（关键词/IP白名单模式）
2. 如果返回签名错误，自动使用 DINGTALK_SECRET 加签重试
3. 无需手动选择安全模式

## 测试

| 安全模式 | 结果 |
|---------|------|
| 关键词 | 直接发送成功 ✅ |
| IP白名单 | 直接发送成功 ✅ |
| 加签（配了SECRET） | 先失败 → 自动加签重试 → 成功 ✅ |
| 加签（未配SECRET） | 失败，提示配置 DINGTALK_SECRET |