### PR TITLE
feat(notification): 优化飞书推送为交互式卡片 (Interactive Message Card)

### DIFF
--- a/trendradar/notification/renderer.py
+++ b/trendradar/notification/renderer.py
@@ -54,12 +54,12 @@ def render_feishu_content(
             word = stat["word"]
             count = stat["count"]
 
-            sequence_display = f"<font color='grey'>[{i + 1}/{total_count}]</font>"
+            sequence_display = f"[{i + 1}/{total_count}]"
 
             if count >= 10:
-                stats_content += f"🔥 {sequence_display} **{word}** : <font color='red'>{count}</font> 条\n\n"
+                stats_content += f"🔥 {sequence_display} **{word}** : {count} 条\n\n"
             elif count >= 5:
-                stats_content += f"📈 {sequence_display} **{word}** : <font color='orange'>{count}</font> 条\n\n"
+                stats_content += f"📈 {sequence_display} **{word}** : {count} 条\n\n"
             else:
                 stats_content += f"📌 {sequence_display} **{word}** : {count} 条\n\n"
 
@@ -133,16 +133,16 @@ def render_feishu_content(
 
         text_content += "⚠️ **数据获取失败的平台：**\n\n"
         for i, id_value in enumerate(report_data["failed_ids"], 1):
-            text_content += f"  • <font color='red'>{id_value}</font>\n"
+            text_content += f"  • {id_value}\n"
 
     # 获取当前时间
     now = get_time_func() if get_time_func else datetime.now()
     text_content += (
-        f"\n\n<font color='grey'>更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}</font>"
+        f"\n\n更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}"
     )
 
     if update_info:
-        text_content += f"\n<font color='grey'>TrendRadar 发现新版本 {update_info['remote_version']}，当前 {update_info['current_version']}</font>"
+        text_content += f"\nTrendRadar 发现新版本 {update_info['remote_version']}，当前 {update_info['current_version']}"
 
     return text_content
 
@@ -310,7 +310,7 @@ def render_rss_feishu_content(
     """
     if not rss_items:
         now = get_time_func() if get_time_func else datetime.now()
-        return f"📭 暂无新的 RSS 订阅内容\n\n<font color='grey'>更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}</font>"
+        return f"📭 暂无新的 RSS 订阅内容\n\n更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}"
 
     # 按 feed_id 分组
     feeds_map: Dict[str, list] = {}
@@ -342,7 +342,7 @@ def render_rss_feishu_content(
                 text_content += f"  {i}. {title}"
 
             if published_at:
-                text_content += f" <font color='grey'>- {published_at}</font>"
+                text_content += f" - {published_at}"
 
             text_content += "\n"
 
@@ -352,7 +352,7 @@ def render_rss_feishu_content(
         text_content += f"\n{separator}\n\n"
 
     now = get_time_func() if get_time_func else datetime.now()
-    text_content += f"<font color='grey'>更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}</font>"
+    text_content += f"更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}"
 
     return text_content
 
@@ -516,7 +516,7 @@ def _render_rss_section_feishu(rss_items: list, separator: str = "---") -> str:
                 text_content += f"  {i}. {title}"
 
             if published_at:
-                text_content += f" <font color='grey'>- {published_at}</font>"
+                text_content += f" - {published_at}"
 
             text_content += "\n"
 

--- a/trendradar/notification/senders.py
+++ b/trendradar/notification/senders.py
@@ -166,12 +166,23 @@ def send_to_feishu(
             f"发送{log_prefix}第 {i}/{len(batches)} 批次，大小：{content_size} 字节 [{report_type}]"
         )
 
-        # 飞书 webhook 只显示 content.text，所有信息都整合到 text 中
         payload = {
-            "msg_type": "text",
-            "content": {
-                "text": batch_content,
-            },
+            "msg_type": "interactive",
+            "card": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": batch_content
+                    }
+                ],
+                "header": {
+                    "template": "blue",
+                    "title": {
+                        "content": "📊 TrendRadar 热点简报",
+                        "tag": "plain_text"
+                    }
+                }
+            }
         }
 
         try:

--- a/trendradar/notification/splitter.py
+++ b/trendradar/notification/splitter.py
@@ -184,9 +184,9 @@ def split_content_into_batches(
         if update_info:
             base_footer += f"\n> TrendRadar 发现新版本 **{update_info['remote_version']}**，当前 **{update_info['current_version']}**"
     elif format_type == "feishu":
-        base_footer = f"\n\n<font color='grey'>更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}</font>"
+        base_footer = f"\n\n更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}"
         if update_info:
-            base_footer += f"\n<font color='grey'>TrendRadar 发现新版本 {update_info['remote_version']}，当前 {update_info['current_version']}</font>"
+            base_footer += f"\nTrendRadar 发现新版本 {update_info['remote_version']}，当前 {update_info['current_version']}"
     elif format_type == "dingtalk":
         base_footer = f"\n\n> 更新时间：{now.strftime('%Y-%m-%d %H:%M:%S')}"
         if update_info:
@@ -315,11 +315,11 @@ def split_content_into_batches(
                     word_header = f"📌 {sequence_display} **{word}** : {count} 条\n\n"
             elif format_type == "feishu":
                 if count >= 10:
-                    word_header = f"🔥 <font color='grey'>{sequence_display}</font> **{word}** : <font color='red'>{count}</font> 条\n\n"
+                    word_header = f"🔥 {sequence_display} **{word}** : {count} 条\n\n"
                 elif count >= 5:
-                    word_header = f"📈 <font color='grey'>{sequence_display}</font> **{word}** : <font color='orange'>{count}</font> 条\n\n"
+                    word_header = f"📈 {sequence_display} **{word}** : {count} 条\n\n"
                 else:
-                    word_header = f"📌 <font color='grey'>{sequence_display}</font> **{word}** : {count} 条\n\n"
+                    word_header = f"📌 {sequence_display} **{word}** : {count} 条\n\n"
             elif format_type == "dingtalk":
                 if count >= 10:
                     word_header = (
@@ -798,7 +798,7 @@ def split_content_into_batches(
 
         for i, id_value in enumerate(report_data["failed_ids"], 1):
             if format_type == "feishu":
-                failed_line = f"  • <font color='red'>{id_value}</font>\n"
+                failed_line = f"  • {id_value}\n"
             elif format_type == "dingtalk":
                 failed_line = f"  • **{id_value}**\n"
             else:
@@ -934,11 +934,11 @@ def _process_rss_stats_section(
                 word_header = f"📌 {sequence_display} **{word}** : {count} 条\n\n"
         elif format_type == "feishu":
             if count >= 10:
-                word_header = f"🔥 <font color='grey'>{sequence_display}</font> **{word}** : <font color='red'>{count}</font> 条\n\n"
+                word_header = f"🔥 {sequence_display} **{word}** : {count} 条\n\n"
             elif count >= 5:
-                word_header = f"📈 <font color='grey'>{sequence_display}</font> **{word}** : <font color='orange'>{count}</font> 条\n\n"
+                word_header = f"📈 {sequence_display} **{word}** : {count} 条\n\n"
             else:
-                word_header = f"📌 <font color='grey'>{sequence_display}</font> **{word}** : {count} 条\n\n"
+                word_header = f"📌 {sequence_display} **{word}** : {count} 条\n\n"
         elif format_type == "dingtalk":
             if count >= 10:
                 word_header = f"🔥 {sequence_display} **{word}** : **{count}** 条\n\n"
@@ -1267,7 +1267,7 @@ def _format_rss_item_line(
         else:
             item_line = f"  {index}. {title}"
         if friendly_time:
-            item_line += f" <font color='grey'>- {friendly_time}</font>"
+            item_line += f" - {friendly_time}"
     elif format_type == "telegram":
         if url:
             item_line = f"  {index}. {title} ({url})"
@@ -1548,9 +1548,9 @@ def _format_standalone_platform_item(item: Dict, index: int, format_type: str, r
         if rank_display:
             item_line += f" {rank_display}"
         if time_display:
-            item_line += f" <font color='grey'>- {time_display}</font>"
+            item_line += f" - {time_display}"
         if count_display:
-            item_line += f" <font color='green'>{count_display}</font>"
+            item_line += f" {count_display}"
 
     elif format_type == "dingtalk":
         if url:
@@ -1644,7 +1644,7 @@ def _format_standalone_rss_item(
         else:
             item_line = f"  {index}. {title}"
         if meta_str:
-            item_line += f" <font color='grey'>- {meta_str}</font>"
+            item_line += f" - {meta_str}"
     elif format_type == "telegram":
         if url:
             item_line = f"  {index}. {title} ({url})"

--- a/trendradar/report/formatter.py
+++ b/trendradar/report/formatter.py
@@ -63,18 +63,18 @@ def format_title_for_platform(
         title_prefix = "🆕 " if title_data.get("is_new") else ""
 
         if show_source:
-            result = f"<font color='grey'>[{title_data['source_name']}]</font> {title_prefix}{formatted_title}"
+            result = f"[{title_data['source_name']}] {title_prefix}{formatted_title}"
         elif show_keyword and keyword:
-            result = f"<font color='blue'>[{keyword}]</font> {title_prefix}{formatted_title}"
+            result = f"[{keyword}] {title_prefix}{formatted_title}"
         else:
             result = f"{title_prefix}{formatted_title}"
 
         if rank_display:
             result += f" {rank_display}"
         if title_data["time_display"]:
-            result += f" <font color='grey'>- {title_data['time_display']}</font>"
+            result += f" - {title_data['time_display']}"
         if title_data["count"] > 1:
-            result += f" <font color='green'>({title_data['count']}次)</font>"
+            result += f" ({title_data['count']}次)"
 
         return result
 

--- a/trendradar/report/helpers.py
+++ b/trendradar/report/helpers.py
@@ -93,8 +93,8 @@ def format_rank_display(ranks: List[int], rank_threshold: int, format_type: str)
         highlight_start = "<font color='red'><strong>"
         highlight_end = "</strong></font>"
     elif format_type == "feishu":
-        highlight_start = "<font color='red'>**"
-        highlight_end = "**</font>"
+        highlight_start = "**"
+        highlight_end = "**"
     elif format_type == "dingtalk":
         highlight_start = "**"
         highlight_end = "**"


### PR DESCRIPTION
### 优化说明

当前的飞书推送使用的是纯文本 `msg_type: text`，导致在部分格式下原本预留的 HTML `<font>` 颜色标签被作为明文打印出来，影响了移动端和 PC 端的信息阅读体验（显得过于密集且杂乱）。

本 PR 对飞书渠道的排版进行了专属升级：
1. **升级为卡片消息**：将 `notification/senders.py` 中的飞书 `payload` 升级为 `msg_type: interactive`，并套用蓝色的 `📊 TrendRadar 热点简报` 卡片头部。由于飞书卡片的 `markdown` 模块原生支持良好的渲染，能让内容展示得非常美观。
2. **清理冗余 HTML 标签**：清理了 `formatter.py`、`helpers.py` 和 `renderer.py` 中对飞书平台特供的 HTML 颜色标签代码，将排版统一回退为纯净的 Markdown（加粗、列表）。

### 测试
- [x] 飞书机器人推送已测试，现在会发送带有蓝色标题栏的精美卡片。 

*提交完全隔离，没有任何配置文件或私钥被提交，请放心 Review！*