### PR TITLE
fix: correct feishu webhook payload format for markdown rendering

### DIFF
--- a/trendradar/notification/senders.py
+++ b/trendradar/notification/senders.py
@@ -167,12 +167,34 @@ def send_to_feishu(
         )
 
         # 飞书 webhook 只显示 content.text，所有信息都整合到 text 中
-        payload = {
-            "msg_type": "interactive",
-            "content": {
-                "text": batch_content,
-            },
-        }
+        # payload = {
+        #     "msg_type": "interactive",
+        #     "content": {
+        #         "text": batch_content,
+        #     },
+        # }
+        # 根据 webhook 类型选择不同的消息格式
+        if "flow/api/trigger-webhook" in webhook_url:
+            # 自建机器人（飞书流程），使用纯文本格式
+            payload = {
+                "msg_type": "text",
+                "content": {
+                    "text": batch_content,
+                },
+            }
+        else:
+            # 群机器人，使用消息卡片格式支持 Markdown 渲染
+            payload = {
+                "msg_type": "interactive",
+                "card": {
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": batch_content,
+                        }
+                    ]
+                },
+            }
 
         try:
             response = requests.post(


### PR DESCRIPTION
## 问题
飞书群机器人推送失败，报错 `params error, unknown card value`。

原因：代码使用了 `msg_type: interactive` 但消息体用的是 `content.text` 结构，
飞书卡片消息要求使用 `card.elements` 结构，两者不匹配。

## 修复
- 群机器人（`open-apis/bot/v2/hook`）：改为正确的 `card.elements.markdown` 结构，支持 Markdown 渲染
- 自建机器人（`flow/api/trigger-webhook`）：保持原有 `content.text` 纯文本格式，向后兼容

## 关联 Issue
Closes #998