### PR TITLE
fix: migrate ubuntu-latest to ubuntu-24.04 for Node.js 24 support

### DIFF
--- a/.github/workflows/clean-crawler.yml
+++ b/.github/workflows/clean-crawler.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   del_runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   crawl:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build-crawler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # 条件：v* 标签（排除 mcp-v*）或手动触发选择 all/crawler
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/mcp-v')) ||
@@ -72,7 +72,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   build-mcp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # 条件：mcp-v* 标签 或手动触发选择 all/mcp
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-v')) ||


### PR DESCRIPTION
## Summary

- 将 `ubuntu-latest` 升级到 `ubuntu-24.04`，主动适配 Node.js 24 运行环境
- 修复 3 个 workflow 文件中的 4 处 `runs-on` 配置

## Why

GitHub Actions 提醒 `actions/checkout@v4` 和 `actions/setup-python@v5` 仍在 Node.js 20 上运行，2026 年 6 月 2 日起将默认切换到 Node.js 24。提前迁移到 `ubuntu-24.04` 可避免 deprecated warning，同时确保 workflow 在新环境下正常工作。

## Changed files

| 文件 | 修改 |
|------|------|
| `.github/workflows/crawler.yml` | `runs-on: ubuntu-latest` → `ubuntu-24.04` |
| `.github/workflows/docker.yml` | `build-crawler` + `build-mcp` 的 `runs-on` |
| `.github/workflows/clean-crawler.yml` | `runs-on: ubuntu-latest` → `ubuntu-24.04` |

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/