### PR TITLE
fix(notification): 修复飞书webhook推送格式错误，改用卡片模式支持富文本渲染

### DIFF
--- a/trendradar/notification/senders.py
+++ b/trendradar/notification/senders.py
@@ -169,9 +169,12 @@ def send_to_feishu(
         # 飞书卡片格式（interactive），支持 markdown 富文本渲染
         import re as _re
         card_content = _re.sub(r"<font[^>]*>(.*?)</font>", r"\1", batch_content)
-        # 提取第一行作为卡片标题
-        first_line = card_content.strip().split("\n")[0].strip("# ").strip()
-        card_title = first_line[:50] if first_line else "TrendRadar 热榜"
+        # 提取时间生成卡片标题，格式：🔥 TrendRadar 热榜 · 2026-03-24 17:22
+        _time_match = _re.search(r"时间：\s*(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})", card_content)
+        if _time_match:
+            card_title = f"🔥 TrendRadar 热榜 · {_time_match.group(1)} {_time_match.group(2)}"
+        else:
+            card_title = "🔥 TrendRadar 热榜"
         payload = {
             "msg_type": "interactive",
             "card": {


### PR DESCRIPTION
  - 原代码使用 msg_type: interactive 但 content 为纯文本结构， 导致飞书 API 返回 "params error, unknown card value"
  - 改为标准卡片格式（interactive card schema 2.0）， 支持 markdown 加粗、可点击链接、分割线及标题栏
  - 发送前清理 <font> 标签（卡片 markdown 不支持），提取首行作为卡片标题


Closes #1021
