### PR TITLE
⚠️ fix(security): pin litellm <1.82.7 — 排除供应链攻击投毒版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ fastmcp>=2.12.0,<2.14.0
 websockets>=13.0,<14.0
 boto3>=1.35.0,<2.0.0
 feedparser>=6.0.0,<7.0.0
-litellm>=1.57.0,<2.0.0
+litellm>=1.57.0,<1.82.7
 tenacity==8.5.0


### PR DESCRIPTION
## ⚠️ litellm v1.82.7 / v1.82.8 供应链攻击

2026年3月24日，litellm 的 v1.82.7 和 v1.82.8 在 PyPI 上被植入恶意代码，会窃取主机上的 SSH 密钥、云凭证、数据库配置等敏感数据。两个版本已从 PyPI 下架。

本项目 `requirements.txt` 中 `litellm>=1.57.0,<2.0.0` 的范围包含了这两个投毒版本。

### 虽然 PyPI 已下架，仍需修复的原因

- **镜像源缓存**：国内常用的清华、阿里云等 PyPI 镜像可能仍缓存着投毒版本，同步删除存在延迟
- **pip 本地缓存**：如果用户在下架前曾安装过，`pip install` 会直接使用 `~/.cache/pip` 中的缓存包，不会重新拉取
- **企业私有 registry**：Artifactory、Nexus 等内部源可能已拉取并缓存了恶意版本
- **防御未来攻击**：收紧版本上限可防止类似事件再次发生时自动安装到新的投毒版本

### 修复

```diff
- litellm>=1.57.0,<2.0.0
+ litellm>=1.57.0,<1.82.7
```

v1.82.6 是官方确认的最后一个安全版本。待 litellm 发布审计后的新版本再调整上限。

### 参考

- litellm 官方安全公告：https://docs.litellm.ai/blog/security-update-march-2026
- GitHub Issue：https://github.com/BerriAI/litellm/issues/24518