### PR TITLE
fix: upgrade fastmcp to 3.2.0 (CVE-2026-32871)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.33.0
 pytz==2026.1
 PyYAML==6.0.3
-fastmcp==2.12.5
+fastmcp==3.2.0
 websockets==13.1
 feedparser==6.0.12
 boto3==1.42.76


### PR DESCRIPTION
## Summary
Upgrade fastmcp from 2.12.5 to 3.2.0 to fix CVE-2026-32871.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-32871 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-32871` |
| **File** | `requirements.txt` |

**Description**: fastmcp: FastMCP: Authenticated Server-Side Request Forgery via path traversal in OpenAPI path parameters

## Changes
- `requirements.txt`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
