### PR TITLE
docs: add animated hero GIF to README

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -6,6 +6,8 @@
 
 Deploy in <strong>30 seconds</strong> — Say goodbye to endless scrolling, only see the news you truly care about
 
+<img src="/_image/trendradar-hero.gif" alt="TrendRadar demo" width="90%">
+
 <a href="https://trendshift.io/repositories/14726" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14726" alt="sansan0%2FTrendRadar | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 [![GitHub Stars](https://img.shields.io/github/stars/sansan0/TrendRadar?style=flat-square&logo=github&color=yellow)](https://github.com/sansan0/TrendRadar/stargazers)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 最快<strong>30秒</strong>部署的热点助手 —— 告别无效刷屏，只看真正关心的新闻资讯
 
+<img src="/_image/trendradar-hero.gif" alt="TrendRadar 演示" width="90%">
+
 <a href="https://trendshift.io/repositories/14726" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14726" alt="sansan0%2FTrendRadar | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 


### PR DESCRIPTION
## Summary

Adds a 1200×675 animated hero GIF (8.2 MB) to the top of both `README.md` and `README-EN.md`, just below the banner and the 30-seconds tagline.

The GIF tells the repo's story in one loop:
1. **Aggregate** — all 11 default platforms (Zhihu, Douyin, Weibo, Bilibili, Baidu, Toutiao, Tieba, Thepaper, Ifeng, Yicai, WSCN) light up with a live headline ticker.
2. **Filter** — keyword chips populate (AI, 自动驾驶, 房价, 美联储…), then the mode flips to AI with natural-language interests, reflecting v6.5.0's `filter.method`.
3. **Push** — all 10 notification channels (WeWork, Feishu, Telegram, DingTalk, Slack, Email, ntfy, Bark, WeChat, Webhook) mark as delivered.

Aims to give a cold visitor the full 'what this does and why' in ~20 seconds, without replacing the existing banner.

## Files changed

- `_image/trendradar-hero.gif` (new, 8.2 MB, 1200×675, 20 s loop)
- `README.md` — one `<img>` line inserted
- `README-EN.md` — one `<img>` line inserted

Happy to iterate on copy, pacing, or palette if anything feels off — or close if not a fit.