### PR TITLE
fix(ai/filter): add logging.warning when JSON extraction fails

### DIFF
--- a/trendradar/ai/filter.py
+++ b/trendradar/ai/filter.py
@@ -8,6 +8,7 @@ AI 智能筛选模块
 """
 
 import hashlib
+import logging
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -291,6 +292,7 @@ class AIFilter:
         """解析标签提取的 AI 响应"""
         json_str = self._extract_json(response)
         if not json_str:
+            logging.warning("[AI filter] JSON extraction failed in tags response; raw snippet: %.200s", (response or ""))
             return []
 
         data = json.loads(json_str)
@@ -398,6 +400,7 @@ class AIFilter:
         """
         json_str = self._extract_json(response)
         if not json_str:
+            logging.warning("[AI filter] JSON extraction failed in classify response; raw snippet: %.200s", (response or ""))
             if self.debug:
                 print(f"[AI筛选][DEBUG] 无法从分类响应中提取 JSON，原始响应前 500 字符: {(response or '')[:500]}")
             return []


### PR DESCRIPTION
## Problem

When JSON extraction from an AI response fails in production mode (`debug=False`), the code silently returns empty/default results:
- `_parse_tags_response` returns `[]` with no log
- `_parse_classify_response` only logs in debug mode

This makes it impossible to detect or diagnose AI response parsing failures in production.

## Fix

Add `logging.warning()` calls in both methods that include the first 200 chars of the raw response, providing visibility into failures without requiring debug mode.

Closes #1087