### PR TITLE
test(mcp): add Streamable HTTP compatibility smoke check

### DIFF
--- a/.github/workflows/mcp-http-compat.yml
+++ b/.github/workflows/mcp-http-compat.yml
@@ -1,0 +1,146 @@
+name: MCP HTTP Compatibility
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "mcp_server/**"
+      - "docker/Dockerfile.mcp"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/mcp-http-compat.yml"
+  pull_request:
+    paths:
+      - "mcp_server/**"
+      - "docker/Dockerfile.mcp"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/mcp-http-compat.yml"
+  workflow_dispatch:
+
+jobs:
+  streamable-http-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install project dependencies
+        run: uv sync --frozen
+
+      - name: Start MCP server
+        run: |
+          nohup uv run python -m mcp_server.server --transport http --host 127.0.0.1 --port 3333 > /tmp/trendradar-mcp.log 2>&1 &
+
+      - name: Wait for MCP server
+        run: |
+          python - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 30
+          last_error = None
+          while time.time() < deadline:
+              try:
+                  with socket.create_connection(("127.0.0.1", 3333), timeout=1):
+                      break
+              except OSError as exc:
+                  last_error = exc
+                  time.sleep(1)
+          else:
+              raise SystemExit(f"MCP server did not start in time: {last_error}")
+          PY
+
+      - name: Verify raw initialize handshake
+        run: |
+          python - <<'PY'
+          import json
+          import httpx
+
+          client = httpx.Client(
+              base_url="http://127.0.0.1:3333",
+              headers={
+                  "accept": "application/json, text/event-stream",
+                  "content-type": "application/json",
+              },
+              timeout=30.0,
+          )
+
+          initialize = client.post(
+              "/mcp",
+              json={
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "method": "initialize",
+                  "params": {
+                      "protocolVersion": "2024-11-05",
+                      "capabilities": {},
+                      "clientInfo": {"name": "compat-smoke", "version": "0.1"},
+                  },
+              },
+          )
+          initialize.raise_for_status()
+          session_id = initialize.headers["mcp-session-id"]
+          assert session_id, "missing MCP session id"
+          assert '"protocolVersion":"2024-11-05"' in initialize.text
+
+          initialized = client.post(
+              "/mcp",
+              headers={"mcp-session-id": session_id},
+              json={
+                  "jsonrpc": "2.0",
+                  "method": "notifications/initialized",
+                  "params": {},
+              },
+          )
+          assert initialized.status_code == 202, initialized.text
+
+          tools = client.post(
+              "/mcp",
+              headers={"mcp-session-id": session_id},
+              json={
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "method": "tools/list",
+                  "params": {},
+              },
+          )
+          tools.raise_for_status()
+          assert '"tools":[' in tools.text, tools.text
+          print(json.dumps({"session_id": session_id, "tools_list_ok": True}))
+          PY
+
+      - name: Verify latest MCP client compatibility
+        run: |
+          uv venv /tmp/mcp-latest
+          uv pip install --python /tmp/mcp-latest/bin/python mcp
+          /tmp/mcp-latest/bin/python - <<'PY'
+          import anyio
+          from mcp import ClientSession
+          from mcp.client.streamable_http import streamable_http_client
+
+          async def main():
+              async with streamable_http_client("http://127.0.0.1:3333/mcp") as (read_stream, write_stream, _):
+                  async with ClientSession(read_stream, write_stream) as session:
+                      result = await session.initialize()
+                      tools = await session.list_tools()
+                      assert result.protocolVersion
+                      assert tools.tools, "expected at least one MCP tool"
+                      print(f"protocol={result.protocolVersion} tools={len(tools.tools)}")
+
+          anyio.run(main)
+          PY
+
+      - name: Show server log on failure
+        if: failure()
+        run: cat /tmp/trendradar-mcp.log

--- a/README-EN.md
+++ b/README-EN.md
@@ -12,7 +12,7 @@ Deploy in <strong>30 seconds</strong> — Say goodbye to endless scrolling, only
 [![GitHub Forks](https://img.shields.io/github/forks/sansan0/TrendRadar?style=flat-square&logo=github&color=blue)](https://github.com/sansan0/TrendRadar/network/members)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg?style=flat-square)](LICENSE)
 [![Version](https://img.shields.io/badge/version-v6.6.1-blue.svg)](https://github.com/sansan0/TrendRadar)
-[![MCP](https://img.shields.io/badge/MCP-v4.0.2-green.svg)](https://github.com/sansan0/TrendRadar)
+[![MCP](https://img.shields.io/badge/MCP-v4.0.3-green.svg)](https://github.com/sansan0/TrendRadar)
 [![RSS](https://img.shields.io/badge/RSS-Feed_Support-orange.svg?style=flat-square&logo=rss&logoColor=white)](https://github.com/sansan0/TrendRadar)
 [![AI Translation](https://img.shields.io/badge/AI-Multi--Language-purple.svg?style=flat-square)](https://github.com/sansan0/TrendRadar)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![GitHub Forks](https://img.shields.io/github/forks/sansan0/TrendRadar?style=flat-square&logo=github&color=blue)](https://github.com/sansan0/TrendRadar/network/members)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg?style=flat-square)](LICENSE)
 [![Version](https://img.shields.io/badge/version-v6.6.1-blue.svg)](https://github.com/sansan0/TrendRadar)
-[![MCP](https://img.shields.io/badge/MCP-v4.0.2-green.svg)](https://github.com/sansan0/TrendRadar)
+[![MCP](https://img.shields.io/badge/MCP-v4.0.3-green.svg)](https://github.com/sansan0/TrendRadar)
 [![RSS](https://img.shields.io/badge/RSS-订阅源支持-orange.svg?style=flat-square&logo=rss&logoColor=white)](https://github.com/sansan0/TrendRadar)
 [![AI翻译](https://img.shields.io/badge/AI-多语言推送-purple.svg?style=flat-square)](https://github.com/sansan0/TrendRadar)
 


### PR DESCRIPTION
This adds a Streamable HTTP compatibility smoke workflow for the MCP server and updates the README MCP version badges to match the current MCP release.

Validation:
- `git diff --check`
- local raw HTTP handshake: `initialize` -> `notifications/initialized` -> `tools/list`
- local latest published `mcp` client against `http://127.0.0.1:3333/mcp`

Related: #1049
