### PR TITLE
fix(ai): improve local model validation

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -3388,7 +3388,7 @@ The simplest way is via environment variables (Recommended for GitHub Secrets or
 | Variable Name | Value | Description |
 |--------------|-------|-------------|
 | `AI_ANALYSIS_ENABLED` | `true` | Enable switch |
-| `AI_API_KEY` | `sk-xxxxxx` | Your API Key |
+| `AI_API_KEY` | `sk-xxxxxx` (optional for Ollama) | Your API Key |
 | `AI_MODEL` | `deepseek/deepseek-chat` | Model identifier (format: `provider/model`) |
 
 **Supported AI Providers** (Based on LiteLLM, supports 100+ providers):
@@ -3398,6 +3398,7 @@ The simplest way is via environment variables (Recommended for GitHub Secrets or
 | **DeepSeek** (Recommended) | `deepseek/deepseek-chat` | Excellent cost-performance ratio for high-frequency analysis |
 | **OpenAI** | `openai/gpt-4o`<br>`openai/gpt-4o-mini` | GPT-4o series |
 | **Google Gemini** | `gemini/gemini-1.5-flash`<br>`gemini/gemini-1.5-pro` | Gemini series |
+| **Local Ollama** | `ollama/llama3` | Local models, usually no `AI_API_KEY` required |
 | **Custom API** | Any format | Use with `AI_API_BASE` |
 
 > 💡 **New Feature**: Now based on [LiteLLM](https://github.com/BerriAI/litellm) unified interface, supporting 100+ AI providers with simpler configuration and better error handling.
@@ -3411,6 +3412,12 @@ The simplest way is via environment variables (Recommended for GitHub Secrets or
 | `AI_MAX_TOKENS` | `5000` | Maximum tokens to generate |
 | `AI_TIMEOUT` | `120` | Request timeout (seconds) |
 | `AI_NUM_RETRIES` | `2` | Number of retries on failure |
+
+> 💡 **Ollama / local model tips**:
+> - Local Ollama usually does not need `AI_API_KEY`
+> - For local runs, `http://127.0.0.1:11434` is fine
+> - **Inside Docker, do not set `AI_API_BASE` to `0.0.0.0`, `127.0.0.1`, or `localhost`**
+> - From a container, use `host.docker.internal`, a service name on the same `docker-compose` network, or the host LAN IP instead
 
 #### Advanced: AI Translation
 

--- a/README.md
+++ b/README.md
@@ -3392,7 +3392,7 @@ app:
 | 变量名 | 填什么 | 说明 |
 |-------|-------|------|
 | `AI_ANALYSIS_ENABLED` | `true` | 开启开关 |
-| `AI_API_KEY` | `sk-xxxxxx` | 你的 API Key |
+| `AI_API_KEY` | `sk-xxxxxx`（Ollama 可留空） | 你的 API Key |
 | `AI_MODEL` | `deepseek/deepseek-chat` | 模型标识（格式：`provider/model`） |
 
 **支持的 AI 提供商**（基于 LiteLLM，支持 100+ 提供商）：
@@ -3402,6 +3402,7 @@ app:
 | **DeepSeek** (推荐) | `deepseek/deepseek-chat` | 性价比极高，适合高频分析 |
 | **OpenAI** | `openai/gpt-4o`<br>`openai/gpt-4o-mini` | GPT-4o 系列 |
 | **Google Gemini** | `gemini/gemini-1.5-flash`<br>`gemini/gemini-1.5-pro` | Gemini 系列 |
+| **本地 Ollama** | `ollama/llama3` | 本地模型，通常不需要 `AI_API_KEY` |
 | **自定义 API** | 任意格式 | 配合 `AI_API_BASE` 使用 |
 
 > 💡 **新特性**：现已基于 [LiteLLM](https://github.com/BerriAI/litellm) 统一接口，支持 100+ AI 提供商，配置更简单、错误处理更完善。
@@ -3415,6 +3416,12 @@ app:
 | `AI_MAX_TOKENS` | `5000` | 最大生成 token 数 |
 | `AI_TIMEOUT` | `120` | 请求超时时间（秒） |
 | `AI_NUM_RETRIES` | `2` | 失败重试次数 |
+
+> 💡 **Ollama / 本地模型提示**：
+> - 本地 Ollama 一般不需要配置 `AI_API_KEY`
+> - 本地运行时可用 `http://127.0.0.1:11434`
+> - **Docker 容器内不要把 `AI_API_BASE` 配成 `0.0.0.0`、`127.0.0.1` 或 `localhost`**
+> - 容器里请改用 `host.docker.internal`、同 `docker-compose` 网络内的服务名，或宿主机局域网 IP
 
 #### 进阶玩法：AI 翻译
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -418,9 +418,13 @@ ai:
   model: "deepseek/deepseek-chat"
 
   api_key: ""                       # API Key（建议使用环境变量 AI_API_KEY）
+                                    # 本地 Ollama 这类无需鉴权的服务可留空
   
   api_base: ""                      # 自定义 API 端点（可选，大多数情况留空）
                                     # 示例: https://api.openai.com/v1（自建代理或兼容接口）
+                                    # 本地 Ollama 常见示例: http://127.0.0.1:11434
+                                    # Docker 容器内不要填写 0.0.0.0 / 127.0.0.1 / localhost
+                                    # 请改用 host.docker.internal、docker 服务名或宿主机局域网 IP
                                     #
                                     # 💡 超级重要：连接任意兼容 OpenAI 协议的模型商
                                     # 如果你使用的模型商不在上述支持列表中，但提供了兼容 OpenAI 的接口：

--- a/trendradar/ai/client.py
+++ b/trendradar/ai/client.py
@@ -8,6 +8,7 @@ AI 客户端模块
 
 import os
 from typing import Any, Dict, List
+from urllib.parse import urlparse
 
 from litellm import completion
 
@@ -38,6 +39,60 @@ class AIClient:
         self.timeout = config.get("TIMEOUT", 120)
         self.num_retries = config.get("NUM_RETRIES", 2)
         self.fallback_models = config.get("FALLBACK_MODELS", [])
+
+    def _get_provider(self) -> str:
+        """从 model 字段提取 provider 名称。"""
+        if not self.model or "/" not in self.model:
+            return ""
+        return self.model.split("/", 1)[0].strip().lower()
+
+    @staticmethod
+    def _is_loopback_host(hostname: str) -> bool:
+        return hostname.lower() in {"127.0.0.1", "localhost", "::1"}
+
+    @staticmethod
+    def _is_running_in_docker() -> bool:
+        """检测当前是否运行在 Docker 容器中。"""
+        return os.path.exists("/.dockerenv") or os.environ.get("container", "").lower() == "docker"
+
+    def _validate_api_base(self) -> tuple[bool, str]:
+        """
+        校验 api_base 是否适合作为客户端访问地址。
+
+        Returns:
+            tuple: (是否有效, 错误信息)
+        """
+        if not self.api_base:
+            return True, ""
+
+        try:
+            parsed = urlparse(self.api_base)
+        except Exception:
+            return False, f"AI API Base 格式错误: {self.api_base}"
+
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return False, (
+                f"AI API Base 格式错误: {self.api_base}，"
+                "请使用 http://host:port 或 https://host/v1 这样的完整地址"
+            )
+
+        hostname = parsed.hostname.lower()
+
+        if hostname == "0.0.0.0":
+            return False, (
+                "AI API Base 不能填写 0.0.0.0。"
+                "0.0.0.0 是服务端监听地址，不是客户端可连接地址；"
+                "请改成实际可访问的主机名或 IP（如 127.0.0.1、host.docker.internal、局域网 IP）。"
+            )
+
+        if self._is_running_in_docker() and self._is_loopback_host(hostname):
+            return False, (
+                "当前运行在 Docker 容器内，AI API Base 不能使用 localhost/127.0.0.1。"
+                "容器内的回环地址只指向容器自身；如果要连接宿主机上的 Ollama 或其他本地模型，"
+                "请改用 host.docker.internal、同 docker-compose 网络内的服务名，或宿主机局域网 IP。"
+            )
+
+        return True, ""
 
     def chat(
         self,
@@ -111,7 +166,14 @@ class AIClient:
         if not self.model:
             return False, "未配置 AI 模型（model）"
 
-        if not self.api_key:
+        provider = self._get_provider()
+        needs_api_key = provider not in {"ollama"}
+
+        api_base_valid, api_base_error = self._validate_api_base()
+        if not api_base_valid:
+            return False, api_base_error
+
+        if not self.api_key and needs_api_key:
             return False, "未配置 AI API Key，请在 config.yaml 或环境变量 AI_API_KEY 中设置"
 
         # 验证模型格式（应该包含 provider/model）


### PR DESCRIPTION
## Summary
- allow `ollama/...` models to pass validation without requiring `AI_API_KEY`
- fail fast on invalid `AI_API_BASE` values such as `0.0.0.0`
- surface a clearer validation error when `AI_API_BASE` points to `localhost` / `127.0.0.1` from inside Docker
- document the correct Ollama / Docker endpoint patterns in `config/config.yaml`, `README.md`, and `README-EN.md`

## Why
Local-model users were hitting two avoidable configuration traps:
- `ollama/...` is a local provider and usually does not need an API key, but validation still treated it like a cloud provider
- `0.0.0.0` and container-local loopback addresses are common misconfigurations for local AI endpoints and currently fail late with opaque runtime errors

This change keeps the diff narrow while making the failure mode much more actionable.

Related: #889

## Validation
- `python -m compileall trendradar/ai/client.py`
- mocked validation checks for:
  - `ollama/llama3` without `AI_API_KEY` -> valid
  - cloud model without `AI_API_KEY` -> still invalid
  - `AI_API_BASE=http://0.0.0.0:11434` -> invalid with explicit guidance
  - Docker + `AI_API_BASE=http://127.0.0.1:11434` -> invalid with container-network guidance
