### PR TITLE
fix: 过滤 enabled: false 的数据源

### DIFF
--- a/mcp_server/services/data_service.py
+++ b/mcp_server/services/data_service.py
@@ -487,7 +487,7 @@ class DataService:
                 "use_proxy": advanced_crawler.get("use_proxy", False),
                 "request_interval": advanced_crawler.get("request_interval", 1),
                 "retry_times": 3,
-                "platforms": [p["id"] for p in platforms_config.get("sources", [])]
+                "platforms": [p["id"] for p in platforms_config.get("sources", []) if p.get("enabled", True)]
             }
 
         if section == "all" or section == "push":


### PR DESCRIPTION
## 修复内容

**根因**：`mcp_server/services/data_service.py` 第 490 行构建 `platforms` 列表时未检查 `enabled` 字段，导致 `config` 中标记为 `enabled: false` 的平台仍被爬取和输出。

**修复**：添加 `if p.get('enabled', True)` 过滤条件，与 crawler 服务端逻辑保持一致。

```python
# Before
"platforms": [p["id"] for p in platforms_config.get("sources", [])]

# After
"platforms": [p["id"] for p in platforms_config.get("sources", []) if p.get("enabled", True)]
```

## 关联 Issue

Fixes #1104

## 测试

本地验证：配置中设置 `enabled: false` 的平台（如 weibo）不再出现在抓取输出中。
