### PR TITLE
fix: 修复 MCP Server 获取 keywords 配置时 JSON 序列化错误

### DIFF
--- a/mcp_server/services/data_service.py
+++ b/mcp_server/services/data_service.py
@@ -43,6 +43,16 @@ class DataService:
         self.parser = ParserService(project_root)
         self.cache = get_cache()
 
+    def _make_json_serializable(self, obj):
+        """将对象中的 re.Pattern 转换为字符串，使其可 JSON 序列化"""
+        if isinstance(obj, re.Pattern):
+            return obj.pattern
+        elif isinstance(obj, dict):
+            return {k: self._make_json_serializable(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._make_json_serializable(item) for item in obj]
+        return obj
+
     def get_latest_news(
         self,
         platforms: Optional[List[str]] = None,
@@ -475,6 +485,9 @@ class DataService:
         # 解析配置文件
         config_data = self.parser.parse_yaml_config()
         word_groups = self.parser.parse_frequency_words()
+        
+        # 将 word_groups 中的正则表达式对象转换为字符串，使其可 JSON 序列化
+        word_groups = self._make_json_serializable(word_groups)
 
         # 根据section返回对应配置
         advanced = config_data.get("advanced", {})


### PR DESCRIPTION
## 问题描述

调用 `get_current_config(section="keywords")` 时，MCP Server 返回错误：

```
Object of type Pattern is not JSON serializable
```

原因是 `word_groups` 列表中包含 `re.Pattern` 对象（正则表达式），Python 的 `json.dumps()` 无法序列化它。

## 根因分析

`_parse_word()` 函数（`trendradar/core/frequency.py`）在解析正则表达式配置时返回：

```python
{
    "word": pattern_str,
    "is_regex": True,
    "pattern": pattern,  # ← 这是 re.compile() 返回的 Pattern 对象
    "display_name": display_name,
}
```

## 修复方案

在 `DataService` 类中添加 `_make_json_serializable()` 辅助方法，在返回 `word_groups` 之前递归地将所有 `re.Pattern` 对象转换为字符串表示。

## 测试

修复后可以正常获取 keywords 配置：

```python
mcp_trendradar_get_current_config(section="keywords")
# 返回: {"word_groups": [...], "total_groups": N}
```
