### PR TITLE
feat(deploy): 新增 k3s/k8s Helm Chart 部署方案

### DIFF
--- a/deploy/helm/trendradar/.helmignore
+++ b/deploy/helm/trendradar/.helmignore
@@ -1,0 +1,3 @@
+files/
+*.md
+.gitkeep

--- a/deploy/helm/trendradar/Chart.yaml
+++ b/deploy/helm/trendradar/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: trendradar
+description: TrendRadar - 多平台热点聚合与 AI 分析工具 (Helm Chart for k3s/k8s)
+type: application
+version: 1.0.0
+appVersion: "latest"
+keywords:
+  - trendradar
+  - hot-list
+  - news-aggregator
+  - ai-analysis
+home: https://github.com/sansan0/TrendRadar
+sources:
+  - https://github.com/sansan0/TrendRadar
+maintainers:
+  - name: trendradar-community

--- a/deploy/helm/trendradar/templates/NOTES.txt
+++ b/deploy/helm/trendradar/templates/NOTES.txt
@@ -1,0 +1,37 @@
+TrendRadar 已安装！
+
+{{- if eq .Values.runMode "cron" }}
+
+📡 Web 报告访问:
+  Port-Forward:  kubectl port-forward svc/{{ include "trendradar.fullname" . }} {{ .Values.webserver.port }}:{{ .Values.webserver.service.port }}
+  浏览器访问:    http://localhost:{{ .Values.webserver.port }}
+
+{{- if eq .Values.webserver.service.type "NodePort" }}
+  NodePort:      http://<NODE_IP>:{{ .Values.webserver.service.nodePort }}
+{{- end }}
+
+{{- if and .Values.ingress.enabled (len .Values.ingress.hosts) }}
+  Ingress:       http://{{ (index .Values.ingress.hosts 0).host }}
+{{- end }}
+
+⏰ 定时任务: {{ .Values.cronSchedule }}
+
+{{- end }}
+
+{{- if .Values.mcp.enabled }}
+
+🤖 MCP 服务:
+  Port-Forward:  kubectl port-forward svc/{{ include "trendradar.mcp.fullname" . }} {{ .Values.mcp.port }}:{{ .Values.mcp.service.port }}
+  MCP 地址:     http://localhost:{{ .Values.mcp.port }}
+
+{{- end }}
+
+📋 常用命令:
+  查看日志:  kubectl logs -f deployment/{{ include "trendradar.fullname" . }}
+  查看状态:  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+  手动执行:  kubectl exec deployment/{{ include "trendradar.fullname" . }} -- python -m trendradar
+  升级版本:  helm upgrade {{ .Release.Name }} deploy/helm/trendradar --set image.tag=vX.Y.Z
+
+⚠️  首次部署须知:
+  确保 config/ 目录已准备就绪 (包含 config.yaml 和 frequency_words.txt)。
+  hostPath 模式: sudo cp -r config/* {{ .Values.persistence.config.hostPath.path }}/

--- a/deploy/helm/trendradar/templates/_helpers.tpl
+++ b/deploy/helm/trendradar/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Chart 名称
+*/}}
+{{- define "trendradar.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+全限定名 (release-name-chart-name)
+*/}}
+{{- define "trendradar.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart 版本标签
+*/}}
+{{- define "trendradar.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+公共标签
+*/}}
+{{- define "trendradar.labels" -}}
+helm.sh/chart: {{ include "trendradar.chart" . }}
+{{ include "trendradar.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+选择器标签
+*/}}
+{{- define "trendradar.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trendradar.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+MCP 全限定名
+*/}}
+{{- define "trendradar.mcp.fullname" -}}
+{{- printf "%s-mcp" (include "trendradar.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+MCP 选择器标签
+*/}}
+{{- define "trendradar.mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trendradar.name" . }}-mcp
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+MCP 公共标签
+*/}}
+{{- define "trendradar.mcp.labels" -}}
+helm.sh/chart: {{ include "trendradar.chart" . }}
+{{ include "trendradar.mcp.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.imageMcp.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Config 卷名
+*/}}
+{{- define "trendradar.configVolumeName" -}}
+{{- printf "%s-config" (include "trendradar.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Output 卷名
+*/}}
+{{- define "trendradar.outputVolumeName" -}}
+{{- printf "%s-output" (include "trendradar.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/deploy/helm/trendradar/templates/configmap.yaml
+++ b/deploy/helm/trendradar/templates/configmap.yaml
@@ -10,3 +10,12 @@ data:
   CRON_SCHEDULE: {{ .Values.cronSchedule | quote }}
   IMMEDIATE_RUN: {{ .Values.immediateRun | quote }}
   WEBSERVER_PORT: {{ .Values.webserver.port | quote }}
+  {{- if .Values.schedule.enabled }}
+  SCHEDULE_ENABLED: {{ .Values.schedule.enabled | quote }}
+  {{- end }}
+  {{- if .Values.schedule.preset }}
+  SCHEDULE_PRESET: {{ .Values.schedule.preset | quote }}
+  {{- end }}
+  {{- if .Values.reportMode }}
+  REPORT_MODE: {{ .Values.reportMode | quote }}
+  {{- end }}

--- a/deploy/helm/trendradar/templates/configmap.yaml
+++ b/deploy/helm/trendradar/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trendradar.fullname" . }}
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+data:
+  TZ: {{ .Values.timezone | quote }}
+  RUN_MODE: {{ .Values.runMode | quote }}
+  CRON_SCHEDULE: {{ .Values.cronSchedule | quote }}
+  IMMEDIATE_RUN: {{ .Values.immediateRun | quote }}
+  WEBSERVER_PORT: {{ .Values.webserver.port | quote }}

--- a/deploy/helm/trendradar/templates/deployment-mcp.yaml
+++ b/deploy/helm/trendradar/templates/deployment-mcp.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trendradar.mcp.fullname" . }}
+  labels:
+    {{- include "trendradar.mcp.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "trendradar.mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "trendradar.mcp.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: mcp
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.imageMcp.repository }}:{{ .Values.imageMcp.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imageMcp.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "trendradar.fullname" . }}
+            - secretRef:
+                name: {{ include "trendradar.fullname" . }}
+          env:
+            - name: MCP_PORT
+              value: {{ .Values.mcp.port | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: mcp
+              containerPort: {{ .Values.mcp.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: mcp
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: mcp
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: output
+              mountPath: /app/output
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.mcpResources | nindent 12 }}
+      volumes:
+        - name: config
+          {{- if and .Values.persistence.config.enabled (eq .Values.persistence.config.type "pvc") }}
+          persistentVolumeClaim:
+            claimName: {{ include "trendradar.fullname" . }}-config
+          {{- else if .Values.persistence.config.enabled }}
+          hostPath:
+            path: {{ .Values.persistence.config.hostPath.path }}
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: output
+          {{- if and .Values.persistence.output.enabled (eq .Values.persistence.output.type "pvc") }}
+          persistentVolumeClaim:
+            claimName: {{ include "trendradar.fullname" . }}-output
+          {{- else if .Values.persistence.output.enabled }}
+          hostPath:
+            path: {{ .Values.persistence.output.hostPath.path }}
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/trendradar/templates/deployment.yaml
+++ b/deploy/helm/trendradar/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trendradar.fullname" . }}
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "trendradar.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "trendradar.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "trendradar.fullname" . }}
+            - secretRef:
+                name: {{ include "trendradar.fullname" . }}
+          env:
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.webserver.port }}
+              protocol: TCP
+          {{- if eq .Values.runMode "cron" }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: output
+              mountPath: /app/output
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          {{- if and .Values.persistence.config.enabled (eq .Values.persistence.config.type "pvc") }}
+          persistentVolumeClaim:
+            claimName: {{ include "trendradar.fullname" . }}-config
+          {{- else if .Values.persistence.config.enabled }}
+          hostPath:
+            path: {{ .Values.persistence.config.hostPath.path }}
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: output
+          {{- if and .Values.persistence.output.enabled (eq .Values.persistence.output.type "pvc") }}
+          persistentVolumeClaim:
+            claimName: {{ include "trendradar.fullname" . }}-output
+          {{- else if .Values.persistence.output.enabled }}
+          hostPath:
+            path: {{ .Values.persistence.output.hostPath.path }}
+            type: DirectoryOrCreate
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/trendradar/templates/ingress.yaml
+++ b/deploy/helm/trendradar/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "trendradar.fullname" . }}
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "trendradar.fullname" $ }}
+                port:
+                  number: {{ $.Values.webserver.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/trendradar/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/trendradar/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "trendradar.fullname" . }}
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "trendradar.selectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/deploy/helm/trendradar/templates/pvc.yaml
+++ b/deploy/helm/trendradar/templates/pvc.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.persistence.config.enabled (eq .Values.persistence.config.type "pvc") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "trendradar.fullname" . }}-config
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.pvc.accessMode }}
+  {{- if .Values.persistence.config.pvc.storageClassName }}
+  storageClassName: {{ .Values.persistence.config.pvc.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.pvc.size }}
+---
+{{- end }}
+{{- if and .Values.persistence.output.enabled (eq .Values.persistence.output.type "pvc") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "trendradar.fullname" . }}-output
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.output.pvc.accessMode }}
+  {{- if .Values.persistence.output.pvc.storageClassName }}
+  storageClassName: {{ .Values.persistence.output.pvc.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.output.pvc.size }}
+{{- end }}

--- a/deploy/helm/trendradar/templates/secret.yaml
+++ b/deploy/helm/trendradar/templates/secret.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trendradar.fullname" . }}
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # --- 通知渠道 ---
+  FEISHU_WEBHOOK_URL: {{ .Values.notifications.feishu.webhookUrl | default "" | quote }}
+  TELEGRAM_BOT_TOKEN: {{ .Values.notifications.telegram.botToken | default "" | quote }}
+  TELEGRAM_CHAT_ID: {{ .Values.notifications.telegram.chatId | default "" | quote }}
+  DINGTALK_WEBHOOK_URL: {{ .Values.notifications.dingtalk.webhookUrl | default "" | quote }}
+  WEWORK_WEBHOOK_URL: {{ .Values.notifications.wework.webhookUrl | default "" | quote }}
+  WEWORK_MSG_TYPE: {{ .Values.notifications.wework.msgType | default "" | quote }}
+  EMAIL_FROM: {{ .Values.notifications.email.from | default "" | quote }}
+  EMAIL_PASSWORD: {{ .Values.notifications.email.password | default "" | quote }}
+  EMAIL_TO: {{ .Values.notifications.email.to | default "" | quote }}
+  EMAIL_SMTP_SERVER: {{ .Values.notifications.email.smtpServer | default "" | quote }}
+  EMAIL_SMTP_PORT: {{ .Values.notifications.email.smtpPort | default "" | quote }}
+  NTFY_SERVER_URL: {{ .Values.notifications.ntfy.serverUrl | default "" | quote }}
+  NTFY_TOPIC: {{ .Values.notifications.ntfy.topic | default "" | quote }}
+  NTFY_TOKEN: {{ .Values.notifications.ntfy.token | default "" | quote }}
+  BARK_URL: {{ .Values.notifications.bark.url | default "" | quote }}
+  SLACK_WEBHOOK_URL: {{ .Values.notifications.slack.webhookUrl | default "" | quote }}
+  GENERIC_WEBHOOK_URL: {{ .Values.notifications.genericWebhook.url | default "" | quote }}
+  GENERIC_WEBHOOK_TEMPLATE: {{ .Values.notifications.genericWebhook.template | default "" | quote }}
+  # --- AI 配置 ---
+  AI_ANALYSIS_ENABLED: {{ .Values.ai.analysisEnabled | default "" | quote }}
+  AI_API_KEY: {{ .Values.ai.apiKey | default "" | quote }}
+  AI_MODEL: {{ .Values.ai.model | default "" | quote }}
+  AI_API_BASE: {{ .Values.ai.apiBase | default "" | quote }}
+  # --- 远程存储 (S3) ---
+  S3_ENDPOINT_URL: {{ .Values.s3.endpointUrl | default "" | quote }}
+  S3_BUCKET_NAME: {{ .Values.s3.bucketName | default "" | quote }}
+  S3_ACCESS_KEY_ID: {{ .Values.s3.accessKeyId | default "" | quote }}
+  S3_SECRET_ACCESS_KEY: {{ .Values.s3.secretAccessKey | default "" | quote }}
+  S3_REGION: {{ .Values.s3.region | default "" | quote }}

--- a/deploy/helm/trendradar/templates/service-mcp.yaml
+++ b/deploy/helm/trendradar/templates/service-mcp.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trendradar.mcp.fullname" . }}
+  labels:
+    {{- include "trendradar.mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - port: {{ .Values.mcp.service.port }}
+      targetPort: mcp
+      protocol: TCP
+      name: mcp
+      {{- if and (eq .Values.mcp.service.type "NodePort") .Values.mcp.service.nodePort }}
+      nodePort: {{ .Values.mcp.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "trendradar.mcp.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/trendradar/templates/service.yaml
+++ b/deploy/helm/trendradar/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trendradar.fullname" . }}
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.webserver.service.type }}
+  ports:
+    - port: {{ .Values.webserver.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.webserver.service.type "NodePort") .Values.webserver.service.nodePort }}
+      nodePort: {{ .Values.webserver.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "trendradar.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/trendradar/templates/tests/test-connection.yaml
+++ b/deploy/helm/trendradar/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "trendradar.fullname" . }}-test-connection"
+  labels:
+    {{- include "trendradar.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  containers:
+    - name: wget
+      image: busybox:latest
+      command: ['wget', '-qO-', '--spider', 'http://{{ include "trendradar.fullname" . }}:{{ .Values.webserver.service.port }}/']
+  restartPolicy: Never

--- a/deploy/helm/trendradar/values.yaml
+++ b/deploy/helm/trendradar/values.yaml
@@ -28,6 +28,12 @@ cronSchedule: "*/30 * * * *"
 immediateRun: true         # 启动时立即执行一次
 timezone: "Asia/Shanghai"
 
+# --- 调度系统 ---
+schedule:
+  enabled: ""                # true | false，留空使用 config.yaml 中的值
+  preset: ""                 # morning_evening | always_on | office_hours | night_owl | custom
+reportMode: ""               # daily | current | incremental，留空使用 config.yaml 中的值
+
 # --- Web Server ---
 webserver:
   port: 8080

--- a/deploy/helm/trendradar/values.yaml
+++ b/deploy/helm/trendradar/values.yaml
@@ -1,0 +1,172 @@
+# ============================================
+# TrendRadar Helm Chart 配置
+# ============================================
+# 完整配置说明: https://github.com/sansan0/TrendRadar
+#
+# 快速开始:
+#   helm install trendradar deploy/helm/trendradar \
+#     --set notifications.telegram.botToken=YOUR_TOKEN \
+#     --set notifications.telegram.chatId=YOUR_CHAT_ID
+
+# --- 镜像配置 ---
+image:
+  repository: wantcat/trendradar
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imageMcp:
+  repository: wantcat/trendradar-mcp
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# --- 副本数 (建议保持 1，避免 cron 重复执行) ---
+replicaCount: 1
+
+# --- 运行模式 ---
+runMode: cron              # cron | once
+cronSchedule: "*/30 * * * *"
+immediateRun: true         # 启动时立即执行一次
+timezone: "Asia/Shanghai"
+
+# --- Web Server ---
+webserver:
+  port: 8080
+  service:
+    type: ClusterIP
+    port: 80
+    # nodePort: 30080      # 设为数字以启用 NodePort (type 需设为 NodePort)
+
+# --- MCP Server ---
+mcp:
+  enabled: false
+  port: 3333
+  host: "0.0.0.0"         # 容器内监听地址
+  service:
+    type: ClusterIP
+    port: 80
+    # nodePort: 30333      # 设为数字以启用 NodePort
+
+# --- 持久化存储 ---
+# 两种模式: hostPath (单节点 k3s 极简) / pvc (多节点/生产)
+persistence:
+  config:
+    enabled: true
+    type: pvc         # hostPath | pvc
+    hostPath:
+      path: /opt/trendradar/config
+    pvc:
+      size: 10Gi
+      storageClassName: ""  # 留空使用集群默认 StorageClass
+      accessMode: ReadWriteOnce
+  output:
+    enabled: true
+    type: pvc         # hostPath | pvc
+    hostPath:
+      path: /opt/trendradar/output
+    pvc:
+      size: 1Gi
+      storageClassName: ""
+      accessMode: ReadWriteOnce
+
+# --- 通知渠道 (多账号用 ; 分隔) ---
+notifications:
+  feishu:
+    webhookUrl: ""
+  telegram:
+    botToken: ""
+    chatId: ""
+  dingtalk:
+    webhookUrl: ""
+  wework:
+    webhookUrl: ""
+    msgType: ""
+  email:
+    from: ""
+    password: ""
+    to: ""
+    smtpServer: ""
+    smtpPort: ""
+  ntfy:
+    serverUrl: "https://ntfy.sh"
+    topic: ""
+    token: ""
+  bark:
+    url: ""
+  slack:
+    webhookUrl: ""
+  genericWebhook:
+    url: ""
+    template: ""
+
+# --- AI 配置 ---
+ai:
+  analysisEnabled: ""
+  apiKey: ""
+  model: ""
+  apiBase: ""
+
+# --- 远程存储 (S3 兼容协议，支持 R2/OSS/COS/S3) ---
+s3:
+  endpointUrl: ""
+  bucketName: ""
+  accessKeyId: ""
+  secretAccessKey: ""
+  region: ""
+
+# --- Ingress ---
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  # className: nginx
+  # annotations:
+  #   cert-manager.io/cluster-issuer: letsencrypt
+  hosts: []
+  #  - host: trendradar.example.com
+  #    paths:
+  #      - path: /
+  #        pathType: Prefix
+  tls: []
+  #  - secretName: trendradar-tls
+  #    hosts:
+  #      - trendradar.example.com
+
+# --- 资源限制 ---
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+mcpResources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# --- Pod 安全上下文 ---
+podSecurityContext: {}
+#  fsGroup: 1000
+
+securityContext: {}
+#  readOnlyRootFilesystem: true
+#  runAsNonRoot: true
+#  runAsUser: 1000
+
+# --- 节点调度 ---
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# --- 额外环境变量 (用于覆盖 config.yaml 中任意配置) ---
+extraEnv: []
+#  - name: SOME_VAR
+#    value: "some_value"
+
+# --- 额外 Volume / VolumeMount (高级用途) ---
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
## 概述

为 TrendRadar 新增 k3s/k8s Helm Chart 部署方案，与现有 Docker 部署方案并行，方便已在 k3s/k8s 环境的用户一键部署。

## 设计原则

- **零侵入**：不修改项目任何已有文件，全部新增于 `deploy/helm/trendradar/`
- **向前兼容**：复用 Docker Hub 公开镜像，利用项目已有的环境变量覆盖机制，与 Docker 部署行为完全一致
- **运维极简**：所有参数通过 `values.yaml` 暴露，一条 `helm upgrade --set` 即可调参

## 架构决策

采用 **Deployment + supercronic** 而非 CronJob，理由：
- 无需拆分 web server 为独立 Deployment
- 容器行为与 Docker 完全一致，社区后续更新自动兼容
- 单个 Deployment 管理主服务，运维更简单

## 新增文件 (16 个)

```
deploy/helm/trendradar/
├── Chart.yaml                    # Chart 元数据
├── values.yaml                   # 运维调参核心入口
├── .helmignore
├── templates/
│   ├── _helpers.tpl              # 模板辅助函数
│   ├── deployment.yaml           # 主服务 (supercronic + web server)
│   ├── deployment-mcp.yaml       # MCP 服务 (条件渲染，默认关闭)
│   ├── service.yaml              # Web Server Service
│   ├── service-mcp.yaml          # MCP Service (条件渲染)
│   ├── ingress.yaml              # Ingress (条件渲染，默认关闭)
│   ├── pvc.yaml                  # PVC (条件渲染)
│   ├── secret.yaml               # 敏感配置 (API keys, tokens)
│   ├── configmap.yaml            # 非敏感环境变量
│   ├── poddisruptionbudget.yaml  # PDB (条件渲染)
│   ├── NOTES.txt                 # 安装后提示
│   └── tests/test-connection.yaml # Helm test hook
└── files/.gitkeep
```

## 快速开始

```bash
# 1. 准备配置文件到 PVC（首次）
kubectl run config-init --image=busybox -- sleep 3600
kubectl cp config/. trendradar-config-init:/data/config/
kubectl delete pod config-init

# 2. 安装
helm install trendradar deploy/helm/trendradar -n trendradar --create-namespace

# 3. 添加通知/AI 配置
helm upgrade trendradar deploy/helm/trendradar -n trendradar \
  --set notifications.feishu.webhookUrl=https://open.feishu.cn/open-apis/bot/v2/hook/xxx \
  --set ai.analysisEnabled=true \
  --set ai.apiKey=sk-xxx \
  --set ai.model=deepseek/deepseek-v4-flash

# 4. 开启 MCP 服务
helm upgrade trendradar deploy/helm/trendradar -n trendradar --set mcp.enabled=true

# 5. 开启 Ingress
helm upgrade trendradar deploy/helm/trendradar -n trendradar \
  --set ingress.enabled=true \
  --set ingress.hosts[0].host=trendradar.example.com
```

## 冒烟测试

已在 k3s (v1.33.5) 单节点集群上完成以下验证：

| 检查项 | 结果 |
|--------|------|
| `helm install` 最小配置安装 | ✅ |
| PVC 自动创建绑定 (local-path) | ✅ |
| 主服务运行 + supercronic cron | ✅ |
| 首次立即执行爬取 11 平台 | ✅ |
| Web Server 响应 | ✅ |
| `helm test` 连通性检查 | ✅ |
| `helm upgrade` 无损升级 | ✅ |
| 既有项目文件零修改 | ✅ |

🤖 Generated with [Aiden x Claude Code]

Co-Authored-By: Aiden