### PR TITLE
fix(notification): 独立展示区(standalone)的国外 RSS 标题在推送中不翻译

### DIFF
--- a/trendradar/notification/dispatcher.py
+++ b/trendradar/notification/dispatcher.py
@@ -145,12 +145,15 @@ class NotificationDispatcher:
                     titles_to_translate.append(item.get("title", ""))
                     title_locations.append(("standalone_platforms", plat_idx, item_idx))
 
-            # 6. 独立展示区 - RSS 源（跳过已翻译的）
-            if not skip_rss:
-                for feed_idx, feed in enumerate(standalone_data.get("rss_feeds", [])):
-                    for item_idx, item in enumerate(feed.get("items", [])):
-                        titles_to_translate.append(item.get("title", ""))
-                        title_locations.append(("standalone_rss", feed_idx, item_idx))
+            # 6. 独立展示区 - RSS 源
+            # 注意：standalone 的 rss_feeds 与 rss_items 是两套独立数据。__main__ 的预翻译
+            # 调用未传入 standalone_data，因此 standalone 的 rss_feeds 从不会在上游被翻译。
+            # skip_rss 仅用于避免 rss_items / rss_new_items 被重复翻译，不应作用于 standalone，
+            # 否则当 ai_translation 启用 + 独立展示区含国外 RSS 源时，其标题在推送中永远不被翻译。
+            for feed_idx, feed in enumerate(standalone_data.get("rss_feeds", [])):
+                for item_idx, item in enumerate(feed.get("items", [])):
+                    titles_to_translate.append(item.get("title", ""))
+                    title_locations.append(("standalone_rss", feed_idx, item_idx))
 
         if not titles_to_translate:
             print("[翻译] 没有需要翻译的内容")


### PR DESCRIPTION
## 问题

启用 AI 翻译（`ai_translation.enabled: true`）、且**独立展示区**（`display.standalone`）包含 RSS 源（`rss_feeds`）时，这些国外 RSS 的标题在 **Webhook 推送**中始终保持原文（例如英文），不会被翻译成目标语言。

（同一配置下，`RSS 订阅` 区域的标题能正常翻译，仅独立展示区的 RSS 源不翻译。）

## 复现

`config.yaml`：

```yaml
ai_translation:
  enabled: true
  language: "中文"
  scope:
    standalone: true
display:
  regions:
    hotlist: false
    rss: false
    standalone: true     # 国外 RSS 源整源直推
  standalone:
    rss_feeds: ["bbc-world", "the-verge", ...]   # 英文 RSS 源
```

推送到飞书/钉钉等：国内热榜（standalone 平台）正常，但 standalone 的国外 RSS 标题仍是英文。

## 根因

`trendradar/notification/dispatcher.py` 的 `translate_content()` 中，独立展示区 RSS 源的翻译被 `if not skip_rss:` 守卫：

```python
# 6. 独立展示区 - RSS 源（跳过已翻译的）
if not skip_rss:
    for feed_idx, feed in enumerate(standalone_data.get("rss_feeds", [])):
        ...
```

而：

1. `__main__.py` 的预翻译调用 `translate_content(...)` **未传入 `standalone_data`**，所以 standalone 的 `rss_feeds` 不会在上游被翻译；
2. 推送路径 `dispatch_all()` 内部以 **`skip_rss=True`** 调用 `translate_content()`（本意是避免 `rss_items`/`rss_new_items` 被重复翻译），却把 standalone 的 `rss_feeds` 也一并跳过。

结果：standalone 的 `rss_feeds` 在两条路径下都不会被翻译，标题恒为原文。

## 修复

standalone 的 `rss_feeds` 与 `rss_items` 是两套独立数据，前者从不会在上游被翻译，因此不应受 `skip_rss` 影响。移除该处的 `skip_rss` 守卫即可（同分支内 standalone 的热榜平台标题本就在此翻译，本次仅补齐 `rss_feeds`，行为对齐）。

改动仅一处，已加注释说明原因。

## 备注

HTML 报告中的独立展示区标题同样未翻译（`__main__.py` 预翻译未传 `standalone_data`），不确定是否为有意设计，故本 PR 未改动该路径，仅修复推送翻译。如需要也可一并处理。