### PR TITLE
修复 README 中损坏的 Star History 星标历史图表

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -3879,7 +3879,7 @@ Any client supporting Model Context Protocol can connect to TrendRadar:
 - https://github.com/sansan0/bilibili-comment-analyzer
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sansan0/TrendRadar&type=Date)](https://www.star-history.com/#sansan0/TrendRadar&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sansan0/TrendRadar&type=Date)](https://star-history.dera.page/#sansan0/TrendRadar&Date)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -3881,7 +3881,7 @@ MCP Inspector 是官方调试工具，用于测试 MCP 连接：
 - https://github.com/sansan0/bilibili-comment-analyzer
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sansan0/TrendRadar&type=Date)](https://www.star-history.com/#sansan0/TrendRadar&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sansan0/TrendRadar&type=Date)](https://star-history.dera.page/#sansan0/TrendRadar&Date)
 
 <br>
 


### PR DESCRIPTION
当前 README 中的 Star History 星标历史图表因上游数据接口限制已无法正常显示，影响项目展示效果。

本次变更将中英文 README 中的星标历史图表链接切换到可正常工作的服务地址，无需任何 API Token 即可展示完整的星标历史数据，欢迎审查与合并。